### PR TITLE
Patch cmake to not rely on pkg-config

### DIFF
--- a/recipe/cmake.patch
+++ b/recipe/cmake.patch
@@ -1,0 +1,113 @@
+diff --git .github/workflows/build.yml .github/workflows/build.yml
+index 60f070e..1deec79 100644
+--- .github/workflows/build.yml
++++ .github/workflows/build.yml
+@@ -21,7 +21,7 @@ jobs:
+     - uses: goanpeca/setup-miniconda@v1
+       with:
+         activate-environment: eigenpy
+-        environment-file: ci/environment.yml
++        environment-file: .github/workflows/conda/environment.yml
+         python-version: 3.7
+     - name: Build Eigenpy
+       shell: cmd /C CALL {0}
+@@ -42,8 +42,6 @@ jobs:
+           -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library ^
+           -DCMAKE_BUILD_TYPE=Release ^
+           -DEIGENPY_SITELIB_ROOT=%CONDA_PREFIX% ^
+-          -DEIGEN3_FOUND=1 ^
+-          -DEIGEN3_INCLUDE_DIRS=%CONDA_PREFIX%\Library\include\eigen3 ^
+           -DPYTHON_EXECUTABLE=%CONDA_PREFIX%\python.exe ^
+           ..
+         cmake --build . --config Release --target install
+diff --git ci/environment.yml .github/workflows/conda/environment.yml
+similarity index 100%
+rename from ci/environment.yml
+rename to .github/workflows/conda/environment.yml
+diff --git .travis.yml .travis.yml
+index 12f0405..a9638f6 100644
+--- .travis.yml
++++ .travis.yml
+@@ -47,16 +47,6 @@ jobs:
+         - BUILDTYPE=Release
+         - TRAVIS_PYTHON_VERSION=35 
+       python: 3.5
+-    - dist: trusty 
+-      env: 
+-        - BUILDTYPE=Release
+-        - TRAVIS_PYTHON_VERSION=27 
+-      python: 2.7
+-    - dist: trusty 
+-      env: 
+-        - BUILDTYPE=Release
+-        - TRAVIS_PYTHON_VERSION=34
+-      python: 3.4
+ 
+ notifications:
+   email:
+diff --git CMakeLists.txt CMakeLists.txt
+index 77d90c8..62d2b13 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -63,7 +63,7 @@ ENDIF(WIN32)
+ # ----------------------------------------------------
+ # --- DEPENDENCIES -----------------------------------
+ # ----------------------------------------------------
+-ADD_REQUIRED_DEPENDENCY("eigen3 >= 3.0.5")
++ADD_PROJECT_DEPENDENCY(Eigen3 REQUIRED PKG_CONFIG_REQUIRES "eigen3 >= 3.0.5")
+ 
+ SET(BOOST_COMPONENTS python)
+ SEARCH_FOR_BOOST()
+@@ -183,7 +183,6 @@ ELSE()
+ ENDIF()
+ 
+ TARGET_LINK_BOOST_PYTHON(${PROJECT_NAME} PUBLIC)
+-PKG_CONFIG_USE_DEPENDENCY(${PROJECT_NAME} eigen3)
+ INSTALL(TARGETS ${PROJECT_NAME}
+   EXPORT ${TARGETS_EXPORT_NAME}
+   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}
+diff --git unittest/CMakeLists.txt unittest/CMakeLists.txt
+index c1a30b0..bd5f822 100644
+--- unittest/CMakeLists.txt
++++ unittest/CMakeLists.txt
+@@ -3,7 +3,7 @@
+ # Copyright (c) 2018-2020 INRIA
+ #
+ 
+-MACRO(ADD_LIB_UNIT_TEST test PKGS)
++MACRO(ADD_LIB_UNIT_TEST test)
+   CREATE_CTEST_BUILD_TESTS_TARGET()
+ 
+   IF(BUILD_TESTING)
+@@ -12,10 +12,6 @@ MACRO(ADD_LIB_UNIT_TEST test PKGS)
+     ADD_LIBRARY(${test} SHARED EXCLUDE_FROM_ALL ${test})
+   ENDIF(BUILD_TESTING)
+ 
+-  FOREACH(PKG ${PKGS})
+-    PKG_CONFIG_USE_DEPENDENCY(${test} ${PKG})
+-  ENDFOREACH(PKG)
+-
+   TARGET_LINK_LIBRARIES(${test} PUBLIC ${PROJECT_NAME})
+   SET_TARGET_PROPERTIES(${test} PROPERTIES PREFIX "")
+ 
+@@ -29,14 +25,14 @@ MACRO(ADD_LIB_UNIT_TEST test PKGS)
+   ENDIF(NOT BUILD_TESTING)
+ ENDMACRO(ADD_LIB_UNIT_TEST)
+ 
+-ADD_LIB_UNIT_TEST(matrix "eigen3")
+-ADD_LIB_UNIT_TEST(geometry "eigen3")
+-ADD_LIB_UNIT_TEST(complex "eigen3")
+-ADD_LIB_UNIT_TEST(return_by_ref "eigen3")
++ADD_LIB_UNIT_TEST(matrix)
++ADD_LIB_UNIT_TEST(geometry)
++ADD_LIB_UNIT_TEST(complex)
++ADD_LIB_UNIT_TEST(return_by_ref)
+ IF(NOT ${EIGEN3_VERSION} VERSION_LESS "3.2.0")
+-  ADD_LIB_UNIT_TEST(eigen_ref "eigen3")
++  ADD_LIB_UNIT_TEST(eigen_ref)
+ ENDIF()
+-ADD_LIB_UNIT_TEST(user_type "eigen3")
++ADD_LIB_UNIT_TEST(user_type)
+ 
+ ADD_PYTHON_UNIT_TEST("py-matrix" "unittest/python/test_matrix.py" "unittest")
+ ADD_PYTHON_UNIT_TEST("py-geometry" "unittest/python/test_geometry.py" "unittest")

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://github.com/stack-of-tasks/{{ name }}/releases/download/v{{ version }}/{{ name }}-{{ version }}.tar.gz
   sha256: dc554a0b45eb4ffe3b1c3d8aa31e7d5db82b0151402c706f3eb7fea4a72bf24d
+  patches:
+    - cmake.patch
 
 build:
   number: 1


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
